### PR TITLE
[2022.10.18] Feat: parse API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "ppthub-server",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppthub-server",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "debug": "~2.6.9",
         "dotenv": "^16.0.3",
         "ejs": "^3.1.8",
         "express": "~4.16.1",
+        "express-fileupload": "^1.4.0",
         "http-errors": "~1.6.3",
         "mongoose": "^6.6.5"
       },
@@ -532,6 +533,17 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1456,6 +1468,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-fileupload": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.4.0.tgz",
+      "integrity": "sha512-RjzLCHxkv3umDeZKeFeMg8w7qe0V09w3B7oGZprr/oO2H/ISCgNzuqzn7gV3HRWb37GjRk429CCpSLS2KNTqMQ==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -3330,6 +3353,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
@@ -4034,6 +4065,14 @@
         "ieee754": "^1.1.13"
       }
     },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -4736,6 +4775,14 @@
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw=="
         }
+      }
+    },
+    "express-fileupload": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/express-fileupload/-/express-fileupload-1.4.0.tgz",
+      "integrity": "sha512-RjzLCHxkv3umDeZKeFeMg8w7qe0V09w3B7oGZprr/oO2H/ISCgNzuqzn7gV3HRWb37GjRk429CCpSLS2KNTqMQ==",
+      "requires": {
+        "busboy": "^1.6.0"
       }
     },
     "fast-deep-equal": {
@@ -6088,6 +6135,11 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string.prototype.matchall": {
       "version": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^16.0.3",
     "ejs": "^3.1.8",
     "express": "~4.16.1",
+    "express-fileupload": "^1.4.0",
     "http-errors": "~1.6.3",
     "mongoose": "^6.6.5"
   },

--- a/src/loaders/middlewares.js
+++ b/src/loaders/middlewares.js
@@ -1,8 +1,10 @@
 const express = require("express");
+const fileupload = require("express-fileupload");
 
 const middlewareLoader = async (app) => {
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: false }));
+  app.use(express.json({ limit: "10mb" }));
+  app.use(express.urlencoded({ extended: false, limit: "10mb" }));
+  app.use(fileupload());
 };
 
 module.exports = middlewareLoader;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,8 +2,14 @@ const express = require("express");
 
 const router = express.Router();
 
-router.get("/", (req, res, next) => {
-  res.json({ result: "PPTHub" });
+router.post("/api/parse", (req, res, next) => {
+  try {
+    const ppt = req.files.pptx;
+
+    res.status(200).json();
+  } catch {
+    res.status(500).json();
+  }
 });
 
 module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const createError = require("http-errors");
 
 const router = express.Router();
 
@@ -8,7 +9,7 @@ router.post("/api/parse", (req, res, next) => {
 
     res.status(200).json();
   } catch {
-    res.status(500).json();
+    next(createError(500));
   }
 });
 


### PR DESCRIPTION


### task card 제목
[POST] /parse 
### Task

[- task card 링크
](https://www.notion.so/vanillacoding/f916c71730e4425f85f143044b5baec1?v=47059edc033e40ac85ad77f29d064b4e&p=a5cc8c17f9394cf68b7359010c7c76e0&pm=c)
### Description

- 작업 내용
1. parse API 구현했습니다
2. 서버로 데이터를 받을 수 있게 express-fileupload 모듈을 이용하였습니다
3. req.files.pptx에서 pptx파일을 확인할 수 있습니다.
### Point
1. view데이터 추출 로직이 아직 구현중이라 일단 status코드만 보내게 하였습니다



### ETC

