### PR TITLE
[2022.10.20] Feat: ppt data differ 유틸 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppthub-server",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "start": "node app.js",

--- a/src/utils/differ.js
+++ b/src/utils/differ.js
@@ -25,7 +25,7 @@ const getMatchingIds = (originIdSet, compareIdSet) => {
   };
 };
 
-const getItemModified = (originItem, compareItem) => {
+const checkItemModified = (originItem, compareItem) => {
   const checkAttributes = ["x", "y", "width", "height"];
   const isSameWith = (attribute) =>
     originItem[attribute] === compareItem[attribute];
@@ -98,7 +98,7 @@ const getSlideDiff = (originSlideItems, compareSlideItems) => {
   matchedItems.forEach((item) => {
     const originItem = originItemsMap.get(item);
     const compareItem = compareItemsMap.get(item);
-    const isModified = getItemModified(originItem, compareItem);
+    const isModified = checkItemModified(originItem, compareItem);
 
     if (isModified && diff === "none") {
       diff = "modified";

--- a/src/utils/differ.js
+++ b/src/utils/differ.js
@@ -1,0 +1,166 @@
+const getMatchingIds = (originIdSet, compareIdSet) => {
+  const { matchedIds, deletedIds } = Array.from(originIdSet).reduce(
+    (acc, originId) => {
+      if (compareIdSet.has(originId)) {
+        compareIdSet.delete(originId);
+        return Object.assign(acc, {
+          matchedIds: acc.matchedIds.concat(originId),
+        });
+      }
+
+      return Object.assign(acc, {
+        deletedIds: acc.deletedIds.concat(originId),
+      });
+    },
+    {
+      matchedIds: [],
+      deletedIds: [],
+    },
+  );
+
+  return {
+    matchedIds,
+    deletedIds,
+    addedIds: Array.from(compareIdSet),
+  };
+};
+
+const getItemModified = (originItem, compareItem) => {
+  const checkAttributes = ["x", "y", "width", "height"];
+  const isSameWith = (attribute) =>
+    originItem[attribute] === compareItem[attribute];
+
+  for (const attribute of checkAttributes) {
+    if (!isSameWith(attribute)) {
+      return true;
+    }
+  }
+
+  if (originItem.type === "text") {
+    const isContentSameWith = (attribute) =>
+      originItem.content[attribute] === compareItem.content[attribute];
+    const checkTextAttributes = [
+      "value",
+      "isBold",
+      "isItalic",
+      "isUnderlined",
+      "fontColor",
+      "size",
+      "backgroundColor",
+    ];
+
+    for (const attribute of checkTextAttributes) {
+      if (!isContentSameWith(attribute)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const getSlideDiff = (originSlideItems, compareSlideItems) => {
+  const originItemsMap = new Map(
+    originSlideItems.map((item) => [item.itemId, item]),
+  );
+  const compareItemsMap = new Map(
+    compareSlideItems.map((item) => [item.itemId, item]),
+  );
+  const {
+    matchedIds: matchedItems,
+    deletedIds: deletedItems,
+    addedIds: addedItems,
+  } = getMatchingIds(
+    new Set(originItemsMap.keys()),
+    new Set(compareItemsMap.keys()),
+  );
+  const slideDiffData = {
+    items: {},
+  };
+  let diff = addedItems.length || deletedItems.length ? "modified" : "none";
+
+  addedItems.forEach((item) => {
+    Object.defineProperty(slideDiffData.items, item, {
+      value: {
+        diff: "added",
+        isChecked: false,
+      },
+    });
+  });
+  deletedItems.forEach((item) => {
+    Object.defineProperty(slideDiffData.items, item, {
+      value: {
+        diff: "deleted",
+        isChecked: false,
+      },
+    });
+  });
+  matchedItems.forEach((item) => {
+    const originItem = originItemsMap.get(item);
+    const compareItem = compareItemsMap.get(item);
+    const isModified = getItemModified(originItem, compareItem);
+
+    if (isModified && diff === "none") {
+      diff = "modified";
+    }
+
+    Object.defineProperty(slideDiffData.items, item, {
+      value: {
+        diff: isModified ? "modified" : "none",
+        ...(isModified ? { isChecked: false } : {}),
+      },
+    });
+  });
+
+  Object.defineProperty(slideDiffData, "diff", {
+    value: diff,
+  });
+
+  return slideDiffData;
+};
+
+const pptDataDiffer = (originPpt, comparePpt) => {
+  const originPptMap = new Map(
+    originPpt.slides.map(({ slideId, items }) => [slideId, items]),
+  );
+  const comparePptMap = new Map(
+    comparePpt.slides.map(({ slideId, items }) => [slideId, items]),
+  );
+  const {
+    matchedIds: matchedSlides,
+    deletedIds: deletedSlides,
+    addedIds: addedSlides,
+  } = getMatchingIds(
+    new Set(originPptMap.keys()),
+    new Set(comparePptMap.keys()),
+  );
+  const diffData = {};
+
+  deletedSlides.forEach((slide) => {
+    Object.defineProperty(diffData, slide, {
+      value: {
+        diff: "deleted",
+        isChecked: false,
+      },
+    });
+  });
+  addedSlides.forEach((slide) => {
+    Object.defineProperty(diffData, slide, {
+      value: {
+        diff: "added",
+        isChecked: false,
+      },
+    });
+  });
+  matchedSlides.forEach((slide) => {
+    const originSlideItems = originPptMap.get(slide);
+    const compareSlideItems = comparePptMap.get(slide);
+    const value = getSlideDiff(originSlideItems, compareSlideItems);
+
+    Object.defineProperty(diffData, slide, { value });
+  });
+
+  return diffData;
+};
+
+module.exports = pptDataDiffer;


### PR DESCRIPTION
###  ppt data differ util 함수

### Task

[Task Card Notiion Link](https://www.notion.so/vanillacoding/diffing-view-data-diff-data-858cd08bc31e48d08f30694eb63ddce5)

### Description
- 두 ppt 파일 간의 변경점을 추적하는 differ util을 작성하였습니다.
- 기본적으로 ppt에 부여된 슬라이드 및 요소 내의 고유값(id)으로 새로 생성되었거나 삭제 된 슬라이드를 추적합니다.
- 같은 슬라이드 내에서 요소의 변경을 추적해 요소 간 변화사항을 반영합니다.
- 함수의 반환값인 diff data는 다음과 같이 구성되어 있습니다.
```
{
  (slideId) : {
    diff: (diffType),
    isChecked: false,
  }
}
```
- 객체 내부에 slide id 값을 키 값으로 가지는 객체로 구성해, 추후 병합로직을 작성할 떄, slideId 값을 통해 시간복잡도를 줄이면서 작업할 수 있도록 구성했습니다.
- diff의 값으로는 diffType들을 가지며, 네 가지의 값이 있습니다.
```
{
  "none": 변경 사항이 없는 슬라이드 or 요소
  "added": 기존에 없었다가, 추가 된 슬라이드 or 요소
  "deleted": 삭제 된 슬라이드 or 요소
  "modified": 수정 된 슬라이드 or 요소
}
```
- 병합 및 시각화(리액트에 data 렌더링) 로직을 작성할 시, 선택 된 항목을 골라내야하므로 `isChecked`라는 값을 임의로 추가하였습니다.
- slide 내의 diff 값이 `modified`인 경우, 부분적으로 수정 된 요소이므로, 수정된 items 값들을 갖고 있습니다.
- 형식은 아래와 같습니다.
```
{
  items: {
    (itemId): {
      diff: (diffType),
      isChecked: false,
    }
  }
}
```

### Point
- 변수명이나 제가 놓치고 실수한 부분이 있는 지 잘 봐주시길 부탁드립니다!

### ETC
[기술 구현 검증 Notion 문서](https://www.notion.so/vanillacoding/view-data-diffing-data-5cd6fca1005e48b68ccb2b2cf067b076)

