### PR TITLE
[2022.10.21] Fix: db스케줄러  수정 및 db TTL변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppthub-server",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "scripts": {
     "start": "node app.js",

--- a/src/loaders/dbScheduler.js
+++ b/src/loaders/dbScheduler.js
@@ -3,7 +3,7 @@ const Ppt = require("../models/Ppt");
 const PptSlide = require("../models/PptSlide");
 
 const dbSchedulerLoader = async () => {
-  const yesterDay = new Date(new Date());
+  const yesterDay = new Date();
   yesterDay.setDate(yesterDay.getDate() - 1);
 
   cron.schedule("0 1 * * *", async () => {

--- a/src/loaders/dbScheduler.js
+++ b/src/loaders/dbScheduler.js
@@ -3,10 +3,10 @@ const Ppt = require("../models/Ppt");
 const PptSlide = require("../models/PptSlide");
 
 const dbSchedulerLoader = async () => {
-  const yesterDay = new Date(new Date().getTime() + 1000 * 60 * 60 * 9);
+  const yesterDay = new Date(new Date());
   yesterDay.setDate(yesterDay.getDate() - 1);
 
-  cron.schedule("0 0 0 * * *", async () => {
+  cron.schedule("0 1 * * *", async () => {
     await Ppt.deleteMany({
       createdAt: {
         $lte: yesterDay.toISOString(),

--- a/src/models/PptSlide.js
+++ b/src/models/PptSlide.js
@@ -7,6 +7,6 @@ const pptSlideSchema = new mongoose.Schema(
   { timestamps: { createdAt: true, updatedAt: false } },
 );
 
-pptSlideSchema.index({ createdAt: 1 }, { expireAfterSeconds: 3600 });
+pptSlideSchema.index({ createdAt: 1 }, { expireAfterSeconds: 86400 });
 
 module.exports = mongoose.model("PptSlide", pptSlideSchema);


### PR DESCRIPTION

### task card 제목

### Task


### Description

1. db 스케줄러의 실행시간을 오전 1시로 변경했습니다.
2. db에 올라가는 데이터의 createAt이 utc로 설정되어있어 스케줄러 안에 db삭제로직의 offset을 제거했습니다
3. pptslide 스키마의 ttl이 잘못설정되어있어 하루로 변경했습니다

### Point


### ETC

