### PR TITLE
[2022.10.22] Feat:  ppt data merge 유틸 추가

### DIFF
--- a/src/config/diffTypes.js
+++ b/src/config/diffTypes.js
@@ -1,0 +1,8 @@
+const DIFF_TYPES = {
+  ADDED: "added",
+  DELETED: "deleted",
+  MODIFIED: "modified",
+  NONE: "none",
+};
+
+module.exports = DIFF_TYPES;

--- a/src/utils/differ.js
+++ b/src/utils/differ.js
@@ -1,3 +1,5 @@
+const DIFF_TYPES = require("../config/diffTypes");
+
 const getMatchingIds = (originIdSet, compareIdSet) => {
   const { matchedIds, deletedIds } = Array.from(originIdSet).reduce(
     (acc, originId) => {
@@ -77,13 +79,16 @@ const getSlideDiff = (originSlideItems, compareSlideItems) => {
   const slideDiffData = {
     items: {},
   };
-  let diff = addedItems.length || deletedItems.length ? "modified" : "none";
+  let diff =
+    addedItems.length || deletedItems.length
+      ? DIFF_TYPES.MODIFIED
+      : DIFF_TYPES.NONE;
 
   addedItems.forEach((item) => {
     Object.defineProperty(slideDiffData.items, item, {
       enumerable: true,
       value: {
-        diff: "added",
+        diff: DIFF_TYPES.ADDED,
         isChecked: false,
       },
     });
@@ -92,7 +97,7 @@ const getSlideDiff = (originSlideItems, compareSlideItems) => {
     Object.defineProperty(slideDiffData.items, item, {
       enumerable: true,
       value: {
-        diff: "deleted",
+        diff: DIFF_TYPES.DELETED,
         isChecked: false,
       },
     });
@@ -102,14 +107,14 @@ const getSlideDiff = (originSlideItems, compareSlideItems) => {
     const compareItem = compareItemsMap.get(item);
     const isModified = checkItemModified(originItem, compareItem);
 
-    if (isModified && diff === "none") {
-      diff = "modified";
+    if (isModified && diff === DIFF_TYPES.NONE) {
+      diff = DIFF_TYPES.MODIFIED;
     }
 
     Object.defineProperty(slideDiffData.items, item, {
       enumerable: true,
       value: {
-        diff: isModified ? "modified" : "none",
+        diff: isModified ? DIFF_TYPES.MODIFIED : DIFF_TYPES.NONE,
         ...(isModified ? { isChecked: false } : {}),
       },
     });
@@ -144,7 +149,7 @@ const pptDataDiffer = (originPpt, comparePpt) => {
     Object.defineProperty(diffData, slide, {
       enumerable: true,
       value: {
-        diff: "deleted",
+        diff: DIFF_TYPES.DELETED,
         isChecked: false,
       },
     });
@@ -153,7 +158,7 @@ const pptDataDiffer = (originPpt, comparePpt) => {
     Object.defineProperty(diffData, slide, {
       enumerable: true,
       value: {
-        diff: "added",
+        diff: DIFF_TYPES.ADDED,
         isChecked: false,
       },
     });

--- a/src/utils/merge.js
+++ b/src/utils/merge.js
@@ -1,0 +1,111 @@
+const getOriginalSlideItems = (originalItems, mergedData) => {
+  const itemsMap = new Map(Object.entries(mergedData.items));
+  const mergedItems = originalItems.items.filter((item) => {
+    if (
+      (itemsMap.get(item.id).diff === "modified" &&
+        !itemsMap.get(item.id).isChecked) ||
+      (itemsMap.get(item.id).diff === "deleted" &&
+        itemsMap.get(item.id).isChecked)
+    ) {
+      return item;
+    }
+
+    return null;
+  });
+
+  return mergedItems;
+};
+
+const getComparableSlideItems = (comparableItems, mergedData) => {
+  const itemsMap = new Map(Object.entries(mergedData.items));
+  const mergedItems = comparableItems.items.filter((item) => {
+    if (
+      (itemsMap.get(item.id).diff === "modified" &&
+        itemsMap.get(item.id).isChecked) ||
+      (itemsMap.get(item.id).diff === "added" &&
+        itemsMap.get(item.id).isChecked)
+    ) {
+      return item;
+    }
+
+    return null;
+  });
+
+  return mergedItems;
+};
+
+const getMergedModifiedSlides = (
+  modifiedOriginalSlides,
+  modifiedComparableSlides,
+) => {
+  return modifiedOriginalSlides.map((slide) => {
+    const tempSlide = slide;
+    const MatchedSlide = modifiedComparableSlides.find(
+      (comparableSlide) => slide.slideId === comparableSlide.slideId,
+    );
+    if (MatchedSlide) {
+      tempSlide.items = [...slide.items, ...MatchedSlide.items];
+      return tempSlide;
+    }
+
+    return slide;
+  });
+};
+
+const getMergedPpt = (originalPpt, comparablePpt, mergeData) => {
+  const mergeDataMap = new Map(Object.entries(mergeData));
+  const mergedPpt = {
+    slideWidth: originalPpt.slideWidth,
+    slideHeight: originalPpt.slideHeight,
+  };
+
+  const modifiedOriginalSlides = originalPpt.slides
+    .filter(
+      (slide) => mergeDataMap.get(`${slide.data.slideId}`).diff === "modified",
+    )
+    .map((slide) => {
+      const { slideId, items } = slide.data;
+      return { slideId, items };
+    });
+  const modifiedComparableSlides = comparablePpt.slides
+    .filter(
+      (slide) => mergeDataMap.get(`${slide.data.slideId}`).diff === "modified",
+    )
+    .map((slide) => {
+      const { slideId, items } = slide.data;
+      return { slideId, items };
+    });
+  const addedSlides = [...originalPpt.slides, ...comparablePpt.slides]
+    .filter((slide) => mergeDataMap.get(`${slide.data.slideId}`).isChecked)
+    .map((slide) => {
+      const { slideId, items } = slide.data;
+      return { slideId, items };
+    });
+
+  for (let i = 0; i < modifiedOriginalSlides.length; i += 1) {
+    const items = getOriginalSlideItems(
+      modifiedOriginalSlides[i],
+      mergeData[modifiedOriginalSlides[i].slideId],
+    );
+    modifiedOriginalSlides[i].items = items;
+  }
+  for (let i = 0; i < modifiedComparableSlides.length; i += 1) {
+    const items = getComparableSlideItems(
+      modifiedComparableSlides[i],
+      mergeData[modifiedComparableSlides[i].slideId],
+    );
+    modifiedComparableSlides[i].items = items;
+  }
+
+  const MergedModifiedSlides = getMergedModifiedSlides(
+    modifiedOriginalSlides,
+    modifiedComparableSlides,
+  );
+
+  const slides = [...MergedModifiedSlides, ...addedSlides];
+  mergedPpt.slides = slides;
+
+  return mergedPpt;
+};
+
+module.exports = getMergedPpt;

--- a/src/utils/merge.js
+++ b/src/utils/merge.js
@@ -1,8 +1,16 @@
 const DIFF_TYPES = require("../config/diffTypes");
 
-const getSlideItems = (originalItems, mergedData, pptType) => {
+/*
+getSlideItems 함수는 slide에서 merge할 아이템들만 선별해서 반환하는 함수입니다
+original ppt이고 아이템의 diff Type이 modified이면서 isChecked가 false인 경우 혹은
+diff Type이 deleted이면서 isChecked 가 true인 경우,
+comparable ppt이고 아이템의 diff Type이 modified이면서 isChecked가 true인 경우 혹은
+diff Type이 added이면서 isChecked 가 true인 경우의 아이템을 선별해 반환합니다.
+*/
+
+const getSlideItems = (slides, mergedData, pptType) => {
   const mergedItemsData = mergedData.items;
-  const mergedItems = originalItems.items.filter((item) => {
+  const mergedItems = slides.items.filter((item) => {
     if (
       (pptType === "original" &&
         mergedItemsData[item.id].diff === DIFF_TYPES.MODIFIED &&
@@ -31,6 +39,12 @@ const getSlideItems = (originalItems, mergedData, pptType) => {
   return mergedItems;
 };
 
+/*
+getMergedModifiedSlides 함수는 diff type이 modified인 slide들을 병합해주는 함수입니다.
+modifiedOriginalSlides와 modifiedComparableSlides에서 공통된 slide를 찾아 slide 아이템을 합치고
+반환을 해줍니다.
+*/
+
 const getMergedModifiedSlides = (
   modifiedOriginalSlides,
   modifiedComparableSlides,
@@ -49,6 +63,11 @@ const getMergedModifiedSlides = (
   });
 };
 
+/*
+getModifiedSlides 함수는 diff type이 modified인 slide들을 찾아서 반환을 해주는 함수입니다.
+또한 DB에서 조회한 ppt의 형식이 변환되었기때문에 map을 이용하여 처음 parse된 형식으로 변환해줍니다.
+*/
+
 const getModifiedSlides = (slides, mergeData) => {
   return slides
     .filter(
@@ -59,6 +78,15 @@ const getModifiedSlides = (slides, mergeData) => {
       return { slideId, items };
     });
 };
+
+/*
+getMergedPpt 함수는 두개의 ppt데이터와 merge요청 데이터를 통해 merge를 해 하나의 새로운 ppt로 만들어 반환해줍니다.
+getModifiedSlides 함수를 이용해 슬라이드 내부 아이템이 변경이된  modifiedSlide들을 찾고
+original ppt와 comparable ppt에서 merge를 해줄 슬라이드들을 addedSlides를 통해 얻습니다.
+getSlideItems함수를 통해 modifiedSlide들 내부에서 merge해줄 아이템들을 찾습니다.
+getMergedModifiedSlides함수를 통해 병합할 original과 comparable modifiedSlide들을 병합해줍니다.
+이 후 추출된 slides들을 모아 새로운 ppt파일을 만들어 반환해줍니다.
+*/
 
 const getMergedPpt = (originalPpt, comparablePpt, mergeData) => {
   const modifiedOriginalSlides = getModifiedSlides(

--- a/src/utils/merge.js
+++ b/src/utils/merge.js
@@ -97,12 +97,12 @@ const getMergedPpt = (originalPpt, comparablePpt, mergeData) => {
     modifiedComparableSlides[i].items = items;
   }
 
-  const MergedModifiedSlides = getMergedModifiedSlides(
+  const mergedModifiedSlides = getMergedModifiedSlides(
     modifiedOriginalSlides,
     modifiedComparableSlides,
   );
 
-  const slides = [...MergedModifiedSlides, ...addedSlides];
+  const slides = [...mergedModifiedSlides, ...addedSlides];
   mergedPpt.slides = slides;
 
   return mergedPpt;


### PR DESCRIPTION
### task card 제목
[유틸] merge 로직 작성 (diff data → .pptx)
### Task

[- task card 링크
](https://www.notion.so/vanillacoding/f916c71730e4425f85f143044b5baec1?v=47059edc033e40ac85ad77f29d064b4e&p=42171be36ace41b4b333093074eba728&pm=c)
### Description

1. 클라이언트에서 머지요청리스트가 들어오면  2개의 ppt데이터를 하나의 ppt데이터로 병합해주는 로직입니다
2. db에서 ppt데이터가 저장되었을때 컬렉션이 나누다보니 불러올 경우 파싱된 데이터와 차이가 있어 원래 파싱한 데이터로 변환을 거친 뒤
머지를 진행합니다
3. 파싱 데이터를 기준으로 pptx파일 변환 로직이 구현되어있어 머지 역시 그에 맞춰서 구현하였습니다

### Point
 변수명이나 시간복잡도에서 더 효율적인 방법이 있으면 조언 부탁드립니다!
### ETC

