### PR TITLE
[2022.10.23] Feat: 피피티의 업로드 기능 및 다운로드 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppthub-server",
-  "version": "0.4.2",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ppthub-server",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "dependencies": {
         "aws-sdk": "^2.1238.0",
         "debug": "~2.6.9",

--- a/src/services/pptServices.js
+++ b/src/services/pptServices.js
@@ -17,6 +17,7 @@ const uploadPpt = async (pptx, fileName) => {
     ContentType:
       "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   };
+
   try {
     await s3.upload(parameter).promise();
   } catch (error) {
@@ -29,10 +30,10 @@ const downloadPpt = async (fileName) => {
     Bucket: process.env.AWS_BUCKET,
     Key: `${fileName}.pptx`,
   };
+
   try {
     await s3.getObject(parameter).promise();
-    const link = s3.getSignedUrl("getObject", parameter).split("?")[0];
-    return link;
+    return s3.getSignedUrl("getObject", parameter).split("?")[0];
   } catch (error) {
     return createError(500);
   }

--- a/src/services/pptServices.js
+++ b/src/services/pptServices.js
@@ -1,0 +1,54 @@
+const AWS = require("aws-sdk");
+const createError = require("http-errors");
+
+const s3 = new AWS.S3({
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  region: process.env.AWS_REGION,
+});
+
+const uploadPpt = async (pptx, fileName) => {
+  const decode = Buffer.from(pptx, "base64");
+  const parameter = {
+    Bucket: process.env.AWS_BUCKET,
+    Key: `${fileName}.pptx`,
+    ACL: "public-read",
+    Body: decode,
+    ContentType:
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  };
+
+  await s3.upload(parameter, (error) => {
+    if (error) {
+      return error;
+    }
+    return true;
+  });
+};
+
+const downloadPpt = async (fileName) => {
+  const parameter = {
+    Bucket: process.env.AWS_BUCKET,
+    Key: `${fileName}.pptx`,
+  };
+
+  await s3.getObject(parameter, (error) => {
+    if (error) {
+      return createError(500);
+    }
+    s3.getSignedUrl("getObject", parameter, (secondError, data) => {
+      if (secondError) {
+        return createError(500);
+      }
+      const link = data.split("?")[0];
+      return link;
+    });
+
+    return true;
+  });
+};
+
+module.exports = {
+  uploadPpt,
+  downloadPpt,
+};

--- a/src/services/pptServices.js
+++ b/src/services/pptServices.js
@@ -17,13 +17,11 @@ const uploadPpt = async (pptx, fileName) => {
     ContentType:
       "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   };
-
-  await s3.upload(parameter, (error) => {
-    if (error) {
-      return error;
-    }
-    return true;
-  });
+  try {
+    await s3.upload(parameter).promise();
+  } catch (error) {
+    createError(500);
+  }
 };
 
 const downloadPpt = async (fileName) => {
@@ -31,21 +29,13 @@ const downloadPpt = async (fileName) => {
     Bucket: process.env.AWS_BUCKET,
     Key: `${fileName}.pptx`,
   };
-
-  await s3.getObject(parameter, (error) => {
-    if (error) {
-      return createError(500);
-    }
-    s3.getSignedUrl("getObject", parameter, (secondError, data) => {
-      if (secondError) {
-        return createError(500);
-      }
-      const link = data.split("?")[0];
-      return link;
-    });
-
-    return true;
-  });
+  try {
+    await s3.getObject(parameter).promise();
+    const link = s3.getSignedUrl("getObject", parameter).split("?")[0];
+    return link;
+  } catch (error) {
+    return createError(500);
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
### task card 제목
[GET] /:ppt_id/download
### Task

- task card 링크
[https://www.notion.so/vanillacoding/GET-ppt_id-download-2c22a8f2e76a4aa0853ef88db79e4124](url)
### Description

- 작업 내용
AWS의 서비스 중 하나인 AWS S3 스토리지 서비스를 이용하였습니다.
upload
aws를 이용하여 사용자가 피피티 정보를 post 요청시 그 피피티에 대한 정보가 aws s3 스토리지에 사용자가 입력한 파일이름으로 저장될 수 있게 서비스를 구현하였습니다.
download
upload와 마찬가지로 사용자가 파일명을 입력하면 그 파일명과 해당하는 정보를 스토리지에서 찾아와 정보를 불러옵니다.

- etc
env 설정이 존재합니다.
개인 키, 개인 비밀번호는 따로 공유해드린 아이디, 비밀번호 값으로 설정해주시면 됩니다.

