### PR TITLE
[2022.10.24] Fix: differ merge 로직 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppthub-server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "start": "node app.js",

--- a/src/utils/differ.js
+++ b/src/utils/differ.js
@@ -63,10 +63,10 @@ const checkItemModified = (originItem, compareItem) => {
 
 const getSlideDiff = (originSlideItems, compareSlideItems) => {
   const originItemsMap = new Map(
-    originSlideItems.map((item) => [item.id.itemName, item]),
+    originSlideItems.map((item) => [item.itemId, item]),
   );
   const compareItemsMap = new Map(
-    compareSlideItems.map((item) => [item.id.itemName, item]),
+    compareSlideItems.map((item) => [item.itemId, item]),
   );
   const {
     matchedIds: matchedItems,

--- a/src/utils/merge.js
+++ b/src/utils/merge.js
@@ -13,22 +13,25 @@ const getSlideItems = (slides, mergedData, pptType) => {
   const mergedItems = slides.items.filter((item) => {
     if (
       (pptType === "original" &&
-        mergedItemsData[item.id].diff === DIFF_TYPES.MODIFIED &&
-        !mergedItemsData[item.id].isChecked) ||
+        mergedItemsData[item.itemId].diff === DIFF_TYPES.MODIFIED &&
+        !mergedItemsData[item.itemId].isChecked) ||
       (pptType === "original" &&
-        mergedItemsData[item.id].diff === DIFF_TYPES.DELETED &&
-        mergedItemsData[item.id].isChecked)
+        mergedItemsData[item.itemId].diff === DIFF_TYPES.DELETED &&
+        mergedItemsData[item.itemId].isChecked) ||
+      (pptType === "original" &&
+        mergedItemsData[item.itemId].diff === DIFF_TYPES.NONE) ||
+      (pptType === "original" && !mergedItemsData[item.itemId])
     ) {
       return true;
     }
 
     if (
       (pptType === "comparison" &&
-        mergedItemsData[item.id].diff === DIFF_TYPES.MODIFIED &&
-        mergedItemsData[item.id].isChecked) ||
+        mergedItemsData[item.itemId].diff === DIFF_TYPES.MODIFIED &&
+        mergedItemsData[item.itemId].isChecked) ||
       (pptType === "comparison" &&
-        mergedItemsData[item.id].diff === DIFF_TYPES.ADDED &&
-        mergedItemsData[item.id].isChecked)
+        mergedItemsData[item.itemId].diff === DIFF_TYPES.ADDED &&
+        mergedItemsData[item.itemId].isChecked)
     ) {
       return true;
     }
@@ -125,7 +128,9 @@ const getMergedPpt = (originalPpt, comparablePpt, mergeData) => {
     modifiedComparableSlides,
   );
 
-  const slides = [...mergedModifiedSlides, ...addedSlides];
+  const slides = [...mergedModifiedSlides, ...addedSlides].sort(
+    (prevSlide, nextSlide) => prevSlide.pageNumber - nextSlide.pageNumber,
+  );
 
   const mergedPpt = {
     slideWidth: originalPpt.slideWidth,


### PR DESCRIPTION
### task card 제목

### Task

- task card 링크

### Description

서버에 전송되는 pptData의 slide item id가 변경되어 그에 맞게 differ,merge로직 수정했습니다
merge로직은 item differ타입이 none이거나 없을 경우 merge할 수 있도록 하였습니다
slide pageNumber 오름차순으로 정렬하여 merge할 수 있게 하였습니다
### Point


### ETC

